### PR TITLE
Reverse the order of "Assign all"

### DIFF
--- a/js/screenGame.js
+++ b/js/screenGame.js
@@ -501,14 +501,19 @@ class ScreenGame {
         //---
         else if (action == 'assignAll') {
             //---
-            window.app.game.addMachineCount(data.itemId)
-            //---
             let item = window.app.game.getItem(data.itemId)
             if (item.inputs) {
+                let inputs = []
                 for (let id in item.inputs) {
-                    this.doClick('assignAll', { itemId:id })
+                    inputs.push(id)
+                }
+                inputs.reverse()
+                for (let id in inputs) {
+                    this.doClick('assignAll', { itemId:inputs[id] })
                 }
             }
+            //---
+            window.app.game.addMachineCount(data.itemId)
         }
     }
     //---


### PR DESCRIPTION
"Assign all" on an item will now assign machines to an item's inputs first before the item itself, starting from the bottom and working up.

For example, if an item's recipe tree is:
```
A (Output)
  B
    C
  D
    E
    F
```

"Assign all" will now assign machines to items in the order `F, E, D, C, B, A` instead of the previous order, `A, B, C, D, E, F`.

In my testing, this allows a player to set the assign amount to "Max" then click "Assign all" repeatedly (with some time between clicks) to research a technology or complete an objective.
The previous order would cause "Assign all" with amount "Max" to get stuck somewhere for even basic recipe trees.