### PR TITLE
Fix item costs for recipes with output >1

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -76,7 +76,9 @@ class GameItem {
             //---
             for (let id in this.recipe.inputs) {
                 //---
-                let item = new GameItem({ id:this.id + '-' + id, cat:'item', recipeName:id, stack:(this.stack == Infinity ? 1 : this.stack) * (this.recipe.inputs[id] / this.recipe.output), toComplete:this.toComplete })
+                let cost = Math.max(this.recipe.inputs[id], (this.stack == Infinity ? 1 : this.stack) * (this.recipe.inputs[id] / this.recipe.output))
+                //---
+                let item = new GameItem({ id:this.id + '-' + id, cat:'item', recipeName:id, stack:cost, toComplete:this.toComplete })
                 game.currentItems.push(item)
                 item.reset(game)
                 //---


### PR DESCRIPTION
In some cases, the cost to make 1 machine was calculated to be less than the required amount for one recipe cycle; this is now fixed by making sure the `stack` is at least as much as needed for one recipe cycle.

The fix most likely does not affect the first (and only as of the time of writing) scenario, but the fix may come into play for scenarios where, for example, machines are crafted in batches.