### PR TITLE
Add new SI prefixes ronna (R) and quetta (Q), replacing unofficial B prefix

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -40,7 +40,7 @@ function formatNumber(value, fixed) {
     //---
     let ret = '', symbol = null
     //---
-    if (absValue >= 1e30) {
+    if (absValue >= 1e33) {
         let start = 33
         for (let i = 0; i < 26; ++i) {
             for (let j = 0; j < 26; ++j) {
@@ -54,7 +54,8 @@ function formatNumber(value, fixed) {
             if (ret != '') break
         }
     }
-    else if (absValue >= 1e27) { ret = (Math.floor(100 * absValue / 1e27) / 100); symbol = 'B'; }
+    else if (absValue >= 1e30) { ret = (Math.floor(100 * absValue / 1e30) / 100); symbol = 'Q'; }
+    else if (absValue >= 1e27) { ret = (Math.floor(100 * absValue / 1e27) / 100); symbol = 'R'; }
     else if (absValue >= 1e24) { ret = (Math.floor(100 * absValue / 1e24) / 100); symbol = 'Y'; }
     else if (absValue >= 1e21) { ret = (Math.floor(100 * absValue / 1e21) / 100); symbol = 'Z'; }
     else if (absValue >= 1e18) { ret = (Math.floor(100 * absValue / 1e18) / 100); symbol = 'E'; }


### PR DESCRIPTION
As of November 2022, two new SI prefixes beyond yotta have been ratified into the International System of Units (SI): ronna (R) = 10<sup>27</sup> and quetta (Q) = 10<sup>30</sup>.

In this implementation, the unofficial prefix bronto (B) = 10<sup>27</sup> was used for a long time and is now replaced with the two official prefixes.