### PR TITLE
Properly format time durations greater than 24 hours

### DIFF
--- a/js/screenGame.js
+++ b/js/screenGame.js
@@ -249,7 +249,7 @@ var TplItem = function(scenario, item) {
                                 html += '<div class="ms-auto col-auto">'
                                     html += '<div id="itemProduction-' + item.id + '" class="row gx-2 align-items-center">'
                                         if (item.time) {
-                                            html += '<div class="col-auto text-end" style="width:55px;">'
+                                            html += '<div class="col-auto text-end" style="min-width:55px;">'
                                                 html += '<small id="itemRemainingTime-' + item.id + '"></small>'
                                                 html += '<div class="progress" style="height:3px;">'
                                                     html += '<div id="itemProgress-' + item.id + '" class="progress-bar bg-success" style="width:0%;"></div>'

--- a/js/utils.js
+++ b/js/utils.js
@@ -18,6 +18,12 @@ function formatTime(value) {
     //---
     if (value < 1) return Math.ceil(value * 1000) + ' <small class="opacity-50">ms</small>'
     //---
+    if (value > 31536000e3) return formatNumber(value / 31536000) + '<small class="opacity-50">yr</small>'
+    //---
+    if (value > 31536000) return Math.floor(value / 31536000) + '<small class="opacity-50">yr</small> ' + formatTime(value % 31536000)
+    //---
+    if (value > 86400) return Math.floor(value / 86400) + '<small class="opacity-50">d</small> ' + formatTime(value % 86400)
+    //---
     let h = Math.floor(value / 3600)
     if (h < 10) { h = '0' + h }
     //---


### PR DESCRIPTION
It used to be that time durations longer than 24 hours had the hours count past 24 even though there are now units for days and hours. For example, a duration of "36:00:00" will now show as "1d 06:00:00" and a duration of "1234:00:00" will now show as "51d 10:00:00." Durations longer than a year will have the unit for years in the formatted output.

To test, just load a save that was last opened more than 24 hours ago.