### PR TITLE
Fix fractional cycle counts in various recipe trees

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -48,6 +48,12 @@ class GameItem {
         //---
         this.max = this.initData.max ? this.initData.max : Infinity
         //---
+        if (recipe.output && this.max !== Infinity) {
+            if (this.max % recipe.output !== 0) {
+                this.max = recipe.output * Math.ceil(this.max / recipe.output)
+            }
+        }
+        //---
         this.count = this.initData.count ? this.initData.count : 0
         this.toComplete = this.initData.toComplete ? this.initData.toComplete : false
         //---


### PR DESCRIPTION
There were 40 cases throughout the default scenario where the number of recipe cycles required to produce enough of an item to make the given machine, tech or objective was fractional. Without this fix, all these cases would have lead to softlocks as, for example, an assembler wouldn't produce a single circuit to top it off as its recipe called for an output of 2, causing production to get stuck. This is fixed by making sure a machine can always run a whole number of times to produce just enough of a given item for the next step.

An alternative would be to just let the machine run that last cycle, producing just enough for the next step and voiding the rest.